### PR TITLE
Add Graph Slicer

### DIFF
--- a/graphslice/LICENSE
+++ b/graphslice/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/graphslice/README.md
+++ b/graphslice/README.md
@@ -1,0 +1,3 @@
+# bn_graphslice
+
+Converts Binary Ninja constructs into NetworkX graphs

--- a/graphslice/__init__.py
+++ b/graphslice/__init__.py
@@ -1,0 +1,19 @@
+from binaryninja.plugin import PluginCommand
+import insnslice, varslice
+
+
+PluginCommand.register_for_medium_level_il_instruction("Slice Variable to Graph",
+                                                       "Creates a networkx graph containing all uses of this variable",
+                                                       varslice.show_graph)
+
+PluginCommand.register_for_medium_level_il_instruction("Slice Instructions to Graph",
+                                                       "Creates a networkx graph containing all uses of this variable",
+                                                       insnslice.show_graph)
+
+PluginCommand.register_for_medium_level_il_function("Graph Return variables",
+                                                    "Create a graph of all the possible return trees",
+                                                    varslice.graph_all_returns)
+
+PluginCommand.register_for_medium_level_il_function("Graph Return Instructions",
+                                                    "Create a graph of all the possible return trees",
+                                                    insnslice.graph_all_returns)

--- a/graphslice/insnslice.py
+++ b/graphslice/insnslice.py
@@ -1,0 +1,111 @@
+import networkx as nx
+from binaryninja import MediumLevelILOperation as op
+from functools import reduce
+from utils import *
+
+
+def get_reliability_score(src, dst):
+    # TODO - support cases other than Phi functions that provide the full value
+    if dst.operation in {op.MLIL_CALL_SSA, op.MLIL_CALL_PARAM_SSA}:
+        return 0.0
+    if dst.operation in {op.MLIL_VAR_PHI, op.MLIL_VAR_SSA, op.MLIL_VAR_ALIASED}:
+        return 1.0
+    return 1.0
+
+
+# Modified from https://gist.github.com/joshwatson/f28b7a2d3356a0ed39823aaea66b50d0
+# Thanks Josh!
+def var_slice_wrapper(instruction, func, slice_func):
+    # switch to SSA form (this does nothing if it's already SSA).
+    instruction_queue = {instruction.ssa_form.instr_index}
+    seen_instructions = set()
+    seen_indices = set()
+    g = nx.DiGraph()
+
+    def add_ssa_inst(_insn):
+        if _insn not in seen_instructions:
+            if type(_insn) is MediumLevelILInstruction:
+                g.add_node(node_token(_insn), instruction=_insn, variables=extract_all_variables(_insn))
+                seen_instructions.add(_insn)
+            else:
+                log.log_error("Can't handle objects of type %s" % type(_insn))
+        else:
+            log.log_warning("Already handled instruction %s" % _insn)
+
+    while instruction_queue:
+        visit_index = instruction_queue.pop()
+
+        if visit_index is None or visit_index in seen_indices:
+            continue
+
+        instruction_to_visit = func[visit_index]
+        add_ssa_inst(instruction_to_visit)
+
+        slice_func(instruction_to_visit, func, instruction_queue, add_ssa_inst, g)
+
+        seen_indices.add(visit_index)
+
+    return prune_orphan_nodes(g)
+
+
+def bw_slice(instruction, f):
+
+    def slice_func(instruction_to_visit, func, instruction_queue, add_ssa_inst, g):
+        for new_var in extract_source_variables(instruction_to_visit):
+            if type(new_var) is SSAVariable:
+                definition = func.get_ssa_var_definition(new_var)
+                if definition is not None:
+                    instruction_queue.add(definition)
+                    src = func[definition]
+                    add_ssa_inst(src)
+                    g.add_edge(node_token(src), node_token(instruction_to_visit),
+                               weight=get_reliability_score(src, instruction_to_visit))
+
+    return var_slice_wrapper(instruction, f, slice_func)
+
+
+def fw_slice(instruction, f):
+
+    def slice_func(instruction_to_visit, func, instruction_queue, add_ssa_inst, g):
+        for new_var in extract_dest_variables(instruction_to_visit):
+            if type(new_var) is SSAVariable:
+                for use in func.get_ssa_var_uses(new_var):
+                    if use is not None:
+                        instruction_queue.add(use)
+                        dst = func[use]
+                        add_ssa_inst(dst)
+                        g.add_edge(node_token(instruction_to_visit), node_token(dst),
+                                   weight=get_reliability_score(instruction_to_visit, dst))
+
+    return var_slice_wrapper(instruction, f, slice_func)
+
+
+def build_graph(instruction, squash_loops=False):
+    func = instruction.function.ssa_form
+    b = bw_slice(instruction, func)
+    f = fw_slice(instruction, func)
+    g = nx.algorithms.operators.binary.compose(b, f)
+
+    return g if not squash_loops else squash_and_relabel(g)
+
+
+def _to_unicode(insn):
+    return str(insn).decode('utf-8')
+
+
+def show_graph(_, instruction):
+    draw_graph(build_graph(instruction))
+
+
+def build_graph_of_all_returns(func):
+    graphs = [build_graph(ret) for ret in get_returns(func)]
+    if graphs:
+        return reduce(lambda a, x: nx.algorithms.operators.binary.compose(a, x), graphs)
+
+
+def graph_all_returns(_, func):
+    draw_graph(build_graph_of_all_returns(func.ssa_form))
+
+
+# TODO - convert variable graph to instruction graph (fully)
+# TODO - handle value analysis for sources

--- a/graphslice/plugin.json
+++ b/graphslice/plugin.json
@@ -1,0 +1,17 @@
+{
+	"plugin": {
+		"name": "Graph Slice",
+		"type": ["ui"],
+		"api": "python2",
+		"description": "Slice a MLIL SSA Variable to a NetworkX Graph",
+		"longdescription": "",
+		"license": {
+			"name": "Apache 2"
+		},
+		"dependencies": {
+			"pip": ["networkx", "matplotlib"]
+		},
+		"version": "1.0 alpha",
+		"author": "Trail of Bits"
+	}
+}

--- a/graphslice/utils.py
+++ b/graphslice/utils.py
@@ -1,0 +1,130 @@
+from binaryninja.mediumlevelil import MediumLevelILOperation, MediumLevelILInstruction, SSAVariable
+import networkx as nx
+import matplotlib.pyplot as plt
+from binaryninja import log
+
+
+def extract_retn_sources(insn):
+    """ Handles cases when the return address doesn't have a source, or sources from something other than rax. """
+    sources = insn.src
+    out = []
+    for s in sources:
+        if s.operation == MediumLevelILOperation.MLIL_VAR_SSA:
+            out.append(s.src)
+        elif s.operation == MediumLevelILOperation.MLIL_CONST_PTR:
+            pass  # TODO - handle constant pointers
+    # TODO - handle returns without a source
+    return out
+
+
+def extract_all_variables(instruction):
+    out = set()
+    if instruction.operation == MediumLevelILOperation.MLIL_RET:
+        for src in extract_retn_sources(instruction):
+            out.add(src)
+    if instruction.vars_read and instruction.operation != MediumLevelILOperation.MLIL_CALL_SSA:
+        out.update((i for i in instruction.vars_read))
+    if instruction.vars_written:
+        out.update((i for i in instruction.vars_written))
+
+    return out
+
+
+# No way to register a plugin callback for the current variable yet, so this is the best we can do
+def extract_source_variables(instruction):
+    if instruction.operation == MediumLevelILOperation.MLIL_RET:
+        return extract_retn_sources(instruction)
+    if instruction.operation == MediumLevelILOperation.MLIL_CALL_SSA:
+        return []
+    return instruction.vars_read
+
+
+def extract_dest_variables(instruction):
+    return instruction.vars_written
+
+
+def node_token(node):
+    if type(node) is MediumLevelILInstruction:
+        return str(node).decode('utf-8')
+    elif type(node) is SSAVariable:
+        return "{}#{}".format(node.var.name, node.version)
+    else:
+        log.log_warn("No way to stringify node of type %s" % type(node))
+        return str(node)
+
+
+def squash_and_relabel(g):
+    if not nx.is_directed_acyclic_graph(g):
+        log.log_info("Squashing loops")
+        g = nx.algorithms.components.condensation(g)  # one line to squash the loops
+        # seven lines to rename the nodes
+        mapping = {}
+        for i in range(len(g.nodes)):
+            if len(g.nodes[i]['members']) == 1:
+                mapping[i] = g.nodes[i]['members'].pop()
+            else:
+                mapping[i] = 'U'.join(n for n in g.nodes[i]['members'])
+        return nx.relabel_nodes(g, mapping)
+
+
+def prune_orphan_nodes(g):
+    """ Sometimes (ie MLIL_IF) we have a source variable that has nothing to do with the variable we want to slice. """
+    subg = list(nx.weakly_connected_component_subgraphs(g))
+    if len(subg):
+        return max(subg, key=len)
+    return g
+
+
+def count(itr):
+    return sum(1 for _ in itr)
+
+
+def get_returns(mlil_func):
+    return filter(lambda x: x.operation == MediumLevelILOperation.MLIL_RET,
+                  (i for bb in mlil_func.ssa_form for i in bb))
+
+
+def get_ret_counts(bv):
+    for func in bv.functions:
+        c = count(get_returns(func.medium_level_il))
+        yield c, func
+
+
+def get_sink_nodes(graph):
+    for node, odeg in graph.out_degree(graph.nodes()).items():
+        if odeg == 0:
+            yield node
+
+
+def get_source_nodes(graph):
+    for node, ideg in graph.in_degree(graph.nodes()).items():
+        if ideg == 0:
+            yield node
+
+
+def _find_multi_returns(bv):
+    for c, f in get_ret_counts(bv):
+        if c > 1:
+            yield f
+
+
+def draw_graph(g):
+    pos = nx.spring_layout(g)
+
+    fw = [(u, v) for (u, v, d) in g.edges(data=True) if d['weight'] == 1.0]
+    pw = [(u, v) for (u, v, d) in g.edges(data=True) if d['weight'] < 1.0]
+
+    nx.draw_networkx(g, pos, edge_color='#bfd7ff')
+    # nx.draw_networkx_nodes(g, pos)
+    nx.draw_networkx_edges(g, pos, edgelist=fw)
+    # nx.draw_networkx_edges(g, pos, edgelist=pw, alpha=0.4, edge_color='b')
+    # nx.draw_networkx_labels(g, pos, font_size=10, font_family='sans-serif')
+
+    plt.axis('off')
+    plt.show()
+
+
+def draw_unweighted(g):
+    nx.draw_networkx(g)
+    plt.axis('off')
+    plt.show()

--- a/graphslice/varslice.py
+++ b/graphslice/varslice.py
@@ -1,0 +1,129 @@
+import networkx as nx
+from functools import reduce
+from utils import *
+from collections import defaultdict
+import pprint as pp
+
+
+def get_reliability_score(src, dst):
+    if src is not None:
+        if src.operation == MediumLevelILOperation.MLIL_VAR_PHI:
+            return 1.0
+    if dst is not None:
+        pass
+    return 1.0
+
+
+# Modified from https://gist.github.com/joshwatson/f28b7a2d3356a0ed39823aaea66b50d0
+# Thanks Josh!
+class VariableSlicer:
+
+    def __init__(self, func):
+        self.func = func
+
+        self.instruction_queue = set()
+        self.seen_variables = set()
+        self.seen_indices = set()
+        self.g = nx.DiGraph()
+        self.insn_map = defaultdict(set)
+
+    def add_ssa_var(self, _var, i):
+        for inst in i:
+            if _var in extract_source_variables(inst):
+                self.insn_map[node_token(_var)].add(inst)
+        if _var not in self.seen_variables:
+            if type(_var) is SSAVariable:
+                self.g.add_node(node_token(_var), variable=_var)
+                self.seen_variables.add(_var)
+            else:
+                log.log_error("Can't handle variables of type %s" % type(_var))
+
+    def do_slice(self, instruction, direction='bw'):
+        self.instruction_queue = {instruction.ssa_form.instr_index}
+
+        while self.instruction_queue:
+            visit_index = self.instruction_queue.pop()
+
+            if visit_index is None or visit_index in self.seen_indices:
+                continue
+
+            instruction_to_visit = self.func[visit_index]
+            for var in extract_all_variables(instruction_to_visit):
+                self.add_ssa_var(var, {instruction_to_visit})
+
+            if 'f' in direction.lower():
+                self.fw_slice(instruction_to_visit)
+            else:
+                self.bw_slice(instruction_to_visit)
+
+            self.seen_indices.add(visit_index)
+
+        nx.set_node_attributes(self.g, self.insn_map, 'instructions')
+
+        return prune_orphan_nodes(self.g)
+
+    def bw_slice(self, instruction_to_visit):
+        for new_var in extract_source_variables(instruction_to_visit):
+            if type(new_var) is SSAVariable:
+                definition = self.func.get_ssa_var_definition(new_var)
+                if definition is not None:
+                    self.instruction_queue.add(definition)
+                    self.add_ssa_var(new_var, {self.func[definition]})
+                for v in instruction_to_visit.vars_written:
+                    self.g.add_edge(node_token(new_var), node_token(v),
+                                    weight=get_reliability_score(self.func[definition] if definition is not None else None,
+                                                                 instruction_to_visit))
+
+    def fw_slice(self, instruction_to_visit):
+        for new_var in extract_dest_variables(instruction_to_visit):
+            if type(new_var) is SSAVariable:
+                uses = set()
+                for use in self.func.get_ssa_var_uses(new_var):
+                    self.instruction_queue.add(use)
+                    uses.add(self.func[use])
+                self.add_ssa_var(new_var, uses)
+                for v in extract_source_variables(instruction_to_visit):
+                    self.g.add_edge(node_token(v), node_token(new_var),
+                                    # TODO - forward slicing is tricky because new_var can have multiple uses
+                                    weight=get_reliability_score(instruction_to_visit, None))
+
+
+def build_graph(instruction, squash_loops=False):
+    print "Building graph!"
+    func = instruction.function.ssa_form
+    g = nx.algorithms.operators.binary.compose(VariableSlicer(func).do_slice(instruction),
+                                               VariableSlicer(func).do_slice(instruction, direction='fw'))
+
+    return g if not squash_loops else squash_and_relabel(g)
+
+
+def var_graph_to_insn_graph(g):
+    mapping = nx.get_node_attributes(g, 'instructions')
+    pp.pprint(mapping)
+    out = nx.DiGraph()
+    out.add_nodes_from(i for l in mapping.values() for i in l)
+    escaped = {insn: node_token(insn) for l in mapping.values() for insn in l}
+    for start, end in g.edges():
+        if mapping[start] != mapping[end]:
+            for s in mapping[start]:
+                for e in mapping[end]:
+                    out.add_edge(s, e, weight=1.0)
+
+    return nx.relabel_nodes(out, escaped)
+
+
+def show_graph(_, instruction):
+    draw_graph(build_graph(instruction))
+
+
+def build_graph_of_all_returns(func):
+    graphs = [build_graph(ret) for ret in get_returns(func)]
+    if graphs:
+        return reduce(lambda a, x: nx.algorithms.operators.binary.compose(a, x), graphs)
+
+
+def graph_all_returns(_, func):
+    draw_graph(build_graph_of_all_returns(func.ssa_form))
+
+
+# TODO - handle value analysis for sources


### PR DESCRIPTION
Old script that converts MLIL instructions/variables into a NetworkX graph. Allows one to run any graph algorithms supported by NetworkX on a binary with minimal effort. 